### PR TITLE
Fix: set referral cookies reliably on cached landing pages (cache-safe AJAX tracking)

### DIFF
--- a/assets/js/tracking-visits.js
+++ b/assets/js/tracking-visits.js
@@ -1,46 +1,96 @@
 jQuery(document).ready(
     function ($) {
-    	
-	    function getCookie(cname) {
-		    var name = cname + "=";
-		    var decodedCookie = decodeURIComponent(document.cookie);
-		    var ca = decodedCookie.split(';');
-		    for(var i = 0; i <ca.length; i++) {
-			    var c = ca[i];
-			    while (c.charAt(0) == ' ') {
-				    c = c.substring(1);
-			    }
-			    if (c.indexOf(name) == 0) {
-				    return c.substring(name.length, c.length);
-			    }
-		    }
-		    return "";
-	    }
-    	
-        var visited_cookie = getCookie("affwp_visit_id");
-        var affiliate_id = getCookie("affwp_affiliate_id")
-        var campaign_cookie = getCookie("affwp_campaign")
 
-        if ( affiliate_id ) {
+        function getCookie(cname) {
+            var name = cname + "=";
+            var decodedCookie = decodeURIComponent(document.cookie);
+            var ca = decodedCookie.split(';');
+            for (var i = 0; i < ca.length; i++) {
+                var c = ca[i];
+                while (c.charAt(0) == ' ') {
+                    c = c.substring(1);
+                }
+                if (c.indexOf(name) == 0) {
+                    return c.substring(name.length, c.length);
+                }
+            }
+            return "";
+        }
+
+        // Read a query-string parameter from the current URL.
+        function getQueryParam(name) {
+            var re = new RegExp("[?&]" + name + "=([^&#]*)", "i");
+            var match = window.location.search.match(re);
+            return match ? decodeURIComponent(match[1].replace(/\+/g, " ")) : "";
+        }
+
+        // Append the referral variables to every link that points to the
+        // parent (store) site so the referral is carried across domains.
+        function rewriteLinks(affiliate_id, visited_cookie, campaign_cookie) {
+            if (!affiliate_id) {
+                return;
+            }
             var url = awp_track_visit_var.url;
-	            if(url.substr(-1) == '/') {
-		            url = url.substr(0, url.length - 1);
-	        }
-	        target_urls = $("a[href^='" + url + "']");
+            if (url.substr(-1) == '/') {
+                url = url.substr(0, url.length - 1);
+            }
+            var target_urls = $("a[href^='" + url + "']");
             var referral_variable = awp_track_visit_var.referral_variable;
             $(target_urls).each(
                 function () {
-                    current_url = $(this).attr("href");
-	                current_url = updateQueryStringParameter(current_url, referral_variable, affiliate_id);
-	                if ( visited_cookie ) {
-		                current_url = current_url + "&visit=" + visited_cookie;
-	                }
-	                if ( campaign_cookie ) {
-		                current_url = current_url + "&campaign=" + campaign_cookie;
-	                }
-                    $(this).attr("href", current_url );
+                    var current_url = $(this).attr("href");
+                    current_url = updateQueryStringParameter(current_url, referral_variable, affiliate_id);
+                    if (visited_cookie) {
+                        current_url = current_url + "&visit=" + visited_cookie;
+                    }
+                    if (campaign_cookie) {
+                        current_url = current_url + "&campaign=" + campaign_cookie;
+                    }
+                    $(this).attr("href", current_url);
                 }
             );
+        }
+
+        var referral_variable = awp_track_visit_var.referral_variable;
+        var url_affiliate_id = getQueryParam(referral_variable);
+        var cookie_affiliate_id = getCookie("affwp_affiliate_id");
+
+        // If the referral variable is present in the URL but the cookie is
+        // missing (e.g. the server-side Set-Cookie header was stripped by a
+        // full-page cache / CDN) or points to a different affiliate, record the
+        // visit over a non-cacheable AJAX request so the cookies are set
+        // reliably. The API keys stay server-side.
+        if (url_affiliate_id && url_affiliate_id !== cookie_affiliate_id && awp_track_visit_var.ajaxurl) {
+
+            var payload = {
+                action: 'cdtawp_track_visit',
+                campaign: getQueryParam('campaign'),
+                url: window.location.href,
+                referrer: document.referrer
+            };
+            payload[referral_variable] = url_affiliate_id;
+
+            $.post(awp_track_visit_var.ajaxurl, payload)
+                .done(
+                    function (response) {
+                        var affiliate_id = url_affiliate_id;
+                        var visit_id = getCookie("affwp_visit_id");
+                        var campaign = getCookie("affwp_campaign");
+                        if (response && response.success && response.data) {
+                            affiliate_id = response.data.affiliate_id || affiliate_id;
+                            visit_id = response.data.visit_id || visit_id;
+                            campaign = response.data.campaign || campaign;
+                        }
+                        rewriteLinks(affiliate_id, visit_id, campaign);
+                    }
+                )
+                .fail(
+                    function () {
+                        rewriteLinks(getCookie("affwp_affiliate_id"), getCookie("affwp_visit_id"), getCookie("affwp_campaign"));
+                    }
+                );
+        } else {
+            rewriteLinks(getCookie("affwp_affiliate_id"), getCookie("affwp_visit_id"), getCookie("affwp_campaign"));
         }
 
         function updateQueryStringParameter(uri, ref_var, aff_id)

--- a/cross-domain-tracker-for-affiliatewp.php
+++ b/cross-domain-tracker-for-affiliatewp.php
@@ -5,7 +5,7 @@
  * Description: Track referrals from different domains.
  * Author: Pratik Chaskar
  * Author URI: https://pratikchaskar.com
- * Version: 1.0.5
+ * Version: 1.0.6
  * Text Domain: affiliatewp-external-visits
  * Domain Path: languages
  * WC requires at least: 3.0

--- a/includes/class-affiliate-wp-track-external-visits.php
+++ b/includes/class-affiliate-wp-track-external-visits.php
@@ -163,7 +163,7 @@ final class Affiliate_WP_Track_External_Visits {
 		define( 'CDTAWP_PLUGIN_CHILD', 'Child' );
 		define( 'CDTAWP_PLUGIN_PARENT', 'Parent' );
 
-		define( 'CDTAWP_VERSION', '1.0.4' );
+		define( 'CDTAWP_VERSION', '1.0.6' );
 	}
 
 	/**
@@ -569,14 +569,16 @@ final class Affiliate_WP_Track_External_Visits {
 		include_once self::$plugin_dir . 'includes/class-affiliate-wp-visits-tracking.php';
 		$visit_tracking = new Affiliate_WP_Visits_Tracking();
 
-		if ( ! is_admin() ) {
-			if ( isset( $options['cdtawp_plugin_type'] ) && CDTAWP_PLUGIN_CHILD === $options['cdtawp_plugin_type'] ) {
-				// Child plugin send tracked visit.
-				$visit_tracking->track_visit_sender();
-			} else {
-				// Parent plugin receive sent visit.
-				$visit_tracking->track_visit_receiver();
-			}
+		// The child site records the visit over a non-cacheable AJAX request
+		// ( Affiliate_WP_Visits_Tracking::ajax_track_visit() ) so a full-page
+		// cache / CDN cannot strip the tracking cookies from a cached
+		// landing-page response. The parent site records the incoming visit on
+		// page load.
+		$is_child = isset( $options['cdtawp_plugin_type'] ) && CDTAWP_PLUGIN_CHILD === $options['cdtawp_plugin_type'];
+
+		if ( ! is_admin() && ! $is_child ) {
+			// Parent plugin receive sent visit.
+			$visit_tracking->track_visit_receiver();
 		}
 	}
 

--- a/includes/class-affiliate-wp-visits-tracking.php
+++ b/includes/class-affiliate-wp-visits-tracking.php
@@ -44,6 +44,23 @@ class Affiliate_WP_Visits_Tracking {
 		$this->define_constants();
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'load_scripts' ) );
+
+		/*
+		 * Record the visit over AJAX so the tracking cookies are set on an
+		 * uncached request. When a full-page cache / CDN serves the landing
+		 * page, it strips (or never generates) the server-side Set-Cookie
+		 * headers, so cookies set during a normal page render can be lost.
+		 * admin-ajax.php responses are never cached, so this path reliably
+		 * sets the cookies regardless of front-end caching.
+		 *
+		 * Registered in the constructor because the AJAX request runs in the
+		 * admin context, where the front-end tracking hooks do not fire.
+		 */
+		$settings = get_option( CDTAWP_SETTINGS_GROUP );
+		if ( isset( $settings['cdtawp_plugin_type'] ) && CDTAWP_PLUGIN_CHILD === $settings['cdtawp_plugin_type'] ) {
+			add_action( 'wp_ajax_cdtawp_track_visit', array( $this, 'ajax_track_visit' ) );
+			add_action( 'wp_ajax_nopriv_cdtawp_track_visit', array( $this, 'ajax_track_visit' ) );
+		}
 	}
 
 	/**
@@ -67,6 +84,7 @@ class Affiliate_WP_Visits_Tracking {
 
 				'referral_variable' => $this->get_option( 'cdtawp_referral_variable' ),
 				'url'               => $this->get_option( 'cdtawp_store_url' ),
+				'ajaxurl'           => admin_url( 'admin-ajax.php' ),
 			)
 		);
 
@@ -175,34 +193,101 @@ class Affiliate_WP_Visits_Tracking {
 		$settings = get_option( CDTAWP_SETTINGS_GROUP );
 		$ref_var  = $this->get_option( 'cdtawp_referral_variable' );
 
-		$affiliate_id = isset( $_GET[ $ref_var ] ) ? absint( $_GET[ $ref_var ] ) : 0; // phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$affiliate_id = isset( $_GET[ $ref_var ] ) ? absint( $_GET[ $ref_var ] ) : 0;
 
 		if ( ! $affiliate_id || ( ! isset( $settings['cdtawp_referral_credit_last'] ) && isset( $_COOKIE['affwp_visit_id'] ) && isset( $_COOKIE['affwp_affiliate_id'] ) ) ) {
 			return;
 		}
 
-		$campaign = isset( $_GET['campaign'] ) ? sanitize_text_field( $_GET['campaign'] ) : '';
+		$campaign = isset( $_GET['campaign'] ) ? sanitize_text_field( wp_unslash( $_GET['campaign'] ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		$referrer = ! empty( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+
+		$this->record_visit( $affiliate_id, $campaign, $this->current_location(), $referrer );
+	}
+
+	/**
+	 * Record referral visit over AJAX (cache-safe).
+	 *
+	 * admin-ajax.php responses are never cached, so the Set-Cookie headers we
+	 * emit here survive full-page caches / CDNs that strip cookies from
+	 * cacheable landing-page responses.
+	 *
+	 * No nonce is verified: this is a public visit-tracking endpoint and a
+	 * nonce would be embedded in (potentially cached) page HTML, defeating the
+	 * cache-safe purpose of the request. This matches the original query-string
+	 * tracking, which was also unauthenticated. The visit creation call to the
+	 * parent site is still authenticated with the stored API keys.
+	 *
+	 * @since 1.0.6
+	 */
+	public function ajax_track_visit() {
+
+		$settings = get_option( CDTAWP_SETTINGS_GROUP );
+		$ref_var  = $this->get_option( 'cdtawp_referral_variable' );
+
+		$affiliate_id = isset( $_POST[ $ref_var ] ) ? absint( wp_unslash( $_POST[ $ref_var ] ) ) : 0;
+
+		if ( ! $affiliate_id || ( ! isset( $settings['cdtawp_referral_credit_last'] ) && isset( $_COOKIE['affwp_visit_id'] ) && isset( $_COOKIE['affwp_affiliate_id'] ) ) ) {
+			wp_send_json_error();
+		}
+
+		$campaign     = isset( $_POST['campaign'] ) ? sanitize_text_field( wp_unslash( $_POST['campaign'] ) ) : '';
+		$landing_page = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
+		$referrer     = isset( $_POST['referrer'] ) ? esc_url_raw( wp_unslash( $_POST['referrer'] ) ) : '';
+
+		$data = $this->record_visit( $affiliate_id, $campaign, $landing_page, $referrer );
+
+		wp_send_json_success( $data );
+	}
+
+	/**
+	 * Set the tracking cookies and create the visit on the parent site.
+	 *
+	 * Shared by the server-side ( track_visit_sender() ) and AJAX
+	 * ( ajax_track_visit() ) entry points.
+	 *
+	 * @param  int    $affiliate_id Affiliate ID from the referral link.
+	 * @param  string $campaign     Campaign name.
+	 * @param  string $landing_page Full landing page URL.
+	 * @param  string $referrer     Referring URL.
+	 * @return array                Tracking data ( affiliate_id, visit_id, campaign ).
+	 * @since  1.0.6
+	 */
+	public function record_visit( $affiliate_id, $campaign = '', $landing_page = '', $referrer = '' ) {
+
+		$settings    = get_option( CDTAWP_SETTINGS_GROUP );
+		$cookie_time = strtotime( '+' . $this->get_option( 'cdtawp_cookie_expiration' ) . ' day' );
 
 		$cookie_affiliate_id   = isset( $_COOKIE['affwp_affiliate_id'] ) ? absint( $_COOKIE['affwp_affiliate_id'] ) : 0;
-		$cookie_affwp_campaign = isset( $_COOKIE['affwp_campaign'] ) ? $_COOKIE['affwp_campaign'] : 0;
+		$cookie_affwp_campaign = isset( $_COOKIE['affwp_campaign'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['affwp_campaign'] ) ) : '';
 
-		$cookie_time = '+' . $this->get_option( 'cdtawp_cookie_expiration' ) . ' day';
-		setcookie( 'affwp_affiliate_id', $affiliate_id, strtotime( $cookie_time ), '/' );
+		setcookie( 'affwp_affiliate_id', $affiliate_id, $cookie_time, '/' );
 
-		if ( ! $cookie_affwp_campaign && isset( $_GET['campaign'] ) ) {
-			setcookie( 'affwp_campaign', $campaign, strtotime( $cookie_time ), '/' );
+		if ( ! $cookie_affwp_campaign && $campaign ) {
+			setcookie( 'affwp_campaign', $campaign, $cookie_time, '/' );
 		}
+
+		$data = array(
+			'affiliate_id' => $affiliate_id,
+			'campaign'     => $campaign,
+			'visit_id'     => isset( $_COOKIE['affwp_visit_id'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['affwp_visit_id'] ) ) : '',
+		);
 
 		if ( $affiliate_id !== $cookie_affiliate_id && $affiliate_id ) {
 
+			// Honour the "credit first referrer" policy.
 			if ( ! isset( $settings['cdtawp_referral_credit_last'] ) && $cookie_affiliate_id ) {
-				setcookie( 'affwp_affiliate_id', $cookie_affiliate_id, strtotime( $cookie_time ), '/' );
+				setcookie( 'affwp_affiliate_id', $cookie_affiliate_id, $cookie_time, '/' );
+				$data['affiliate_id'] = $cookie_affiliate_id;
 			}
-			setcookie( 'affwp_campaign', $campaign, strtotime( $cookie_time ), '/' );
-			$current_page_url = explode( '?', $this->current_location() );
-			$landing_page     = $current_page_url[0];
-			$store_url        = $this->get_option( 'cdtawp_store_url' ) . '/wp-json/affwp/v1/visits';
-			$referrer         = ! empty( $_SERVER['HTTP_REFERER'] ) ? esc_url( $_SERVER['HTTP_REFERER'] ) : '';
+			setcookie( 'affwp_campaign', $campaign, $cookie_time, '/' );
+
+			$landing_parts = explode( '?', $landing_page );
+			$landing_page  = $landing_parts[0];
+			$store_url     = $this->get_option( 'cdtawp_store_url' ) . '/wp-json/affwp/v1/visits';
 
 			$pload = array(
 				'method'      => 'POST',
@@ -221,7 +306,7 @@ class Affiliate_WP_Visits_Tracking {
 				array(
 					'affiliate_id' => $affiliate_id,
 					'ip'           => $this->get_ip(),
-					'url'          => esc_url( $landing_page ),
+					'url'          => esc_url_raw( $landing_page ),
 					'campaign'     => $campaign,
 					'referrer'     => $referrer,
 				),
@@ -233,10 +318,14 @@ class Affiliate_WP_Visits_Tracking {
 
 			if ( ! is_wp_error( $response ) && ( 201 === $code || 200 === $code ) ) {
 				$body = json_decode( wp_remote_retrieve_body( $response ) );
-				setcookie( 'affwp_visit_id', $body->visit_id, strtotime( $cookie_time ), '/' );
+				if ( isset( $body->visit_id ) ) {
+					setcookie( 'affwp_visit_id', $body->visit_id, $cookie_time, '/' );
+					$data['visit_id'] = $body->visit_id;
+				}
 			}
 		}
 
+		return $data;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pratikchaskar
 Tags: AffiliateWp, Cross domain tracking
 Requires at least: 4.4
 Tested up to: 6.9
-Stable tag: 1.0.5
+Stable tag: 1.0.6
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -44,6 +44,9 @@ No, you just need to select the plugin type as parent/child inside the plugin se
 
 
 == Changelog ==
+
+= Version 1.0.6 =
+* Fix: Referral tracking cookies were not being set on cached landing pages. Visits are now recorded on the child site over a non-cacheable AJAX request so the cookies are set reliably even behind a full-page cache or CDN (e.g. Cloudflare) that strips Set-Cookie headers.
 
 = Version 1.0.5 - Thursday, 11th July 2024 =
 * Improvement: Compatibility with WordPress 6.6.


### PR DESCRIPTION
## Problem

On the **child** site the referral tracking cookies (`affwp_affiliate_id`, `affwp_visit_id`, `affwp_campaign`) are set with PHP `setcookie()` during the normal page render (`track_visit_sender()` on `plugins_loaded`).

When the landing page is served through a **full-page cache / CDN**, this breaks:

- If the page is served **from** cache → PHP never runs → `setcookie()` never fires.
- If the page is **cacheable** (Cloudflare `cf-cache-status: MISS`) → PHP runs and emits the `Set-Cookie` headers, but **Cloudflare strips `Set-Cookie` from cacheable responses** (to avoid caching one visitor's cookie for everyone). The cookie never reaches the browser.

This is most visible on the **home URL** (e.g. `https://site.com/?bsf=123`), which is the most aggressively cached page. Verified live on wpastra.com:

| URL | `cf-cache-status` | `affwp_affiliate_id` set? |
|---|---|---|
| `/?bsf=123` (home) | `MISS` (cacheable) | ❌ stripped |
| `/about/?bsf=123` | `BYPASS` | ✅ |
| `/pricing/?bsf=123` | 302 redirect | ✅ |

Because the cookie is missing, `tracking-visits.js` finds no `affwp_affiliate_id`, so it never rewrites the cross-domain links and the referral is lost.

## Fix

Record the visit on the child over a **non-cacheable `admin-ajax.php` request** instead of during the cached page render. admin-ajax responses are never cached, so the `Set-Cookie` headers are not stripped and the cookies are set reliably regardless of front-end caching. The authenticated visit-creation call to the parent still runs server-side, so the API keys stay private.

### Changes
- Register `wp_ajax_cdtawp_track_visit` / `wp_ajax_nopriv_cdtawp_track_visit` on the child (in the constructor, since AJAX runs in the admin context).
- Extract the cookie + visit-creation logic into a shared `record_visit()` used by both the server-side and AJAX paths (no duplication).
- `tracking-visits.js` now fires the AJAX request when the referral variable is present in the URL but the cookie is missing / points to a different affiliate, then rewrites the cross-domain links using the returned data. When the cookie already matches, behaviour is unchanged (no extra request).
- Stop the redundant server-side sender on the child to avoid double-counting visits.
- Bump version to `1.0.6`.

### Notes
- The plugin already hard-depends on JS for cross-domain link rewriting, so moving visit recording to a JS-triggered AJAX request adds no new requirement.
- No nonce is verified on the endpoint: it is a public visit-tracking action, and a nonce baked into cached page HTML would defeat the cache-safe purpose (and go stale on cached pages). This matches the previous query-string tracking, which was also unauthenticated.
- The parent-side receiver (`track_visit_receiver()`) is unchanged; those links carry a `visit` param and are effectively uncacheable, but a similar hardening could follow if needed.
- A Cloudflare cache rule (bypass cache when the `bsf` query param is present) is a complementary operational fix already applied on wpastra.com; this PR makes the plugin resilient on sites without such a rule.

## Testing
- `php -l` clean on all changed PHP files; `node --check` clean on the JS.
- Manual: with the referral param on a cached home URL, the AJAX request returns `success` and the browser receives `Set-Cookie: affwp_affiliate_id` / `affwp_visit_id`; cross-domain links are rewritten with `?<ref>=<id>&visit=<id>`.
